### PR TITLE
RollLogin: use in BottomSheetModal

### DIFF
--- a/components/BottomSheetModal.js
+++ b/components/BottomSheetModal.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useState, useRef } from "react";
+
+export default function BottomSheetModal({ children, onExit }) {
+  const [didMount, setDidMount] = useState(false);
+  const modalRef = useRef();
+
+  useEffect(() => {
+    setTimeout(() => {
+      setDidMount(true);
+    }, 50);
+    return () => document.body.classList.remove("fixed");
+  }, []);
+  function exit() {
+    setDidMount(false);
+    setTimeout(() => {
+      onExit();
+    }, 100);
+  }
+  return (
+    <div
+      ref={modalRef}
+      className="fixed inset-0 z-10 bg-black bg-opacity-75 flex flex-col"
+    >
+      <div onClick={exit} className="h-32 w-full" />
+      <div
+        className={
+          "flex-auto w-full bg-white rounded-t-lg relative transform transition-transform duration-300 ease-in-out " +
+          (didMount ? "translate-y-0" : "translate-y-full")
+        }
+      >
+        <div
+          className="absolute w-32 top-0 border-2 border-gray-400 m-6"
+          style={{ left: "26%" }}
+        />
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,22 +1,20 @@
-import { useRef, useLayoutEffect, useEffect, useState } from "react";
-import Nav from "./Nav";
+import { useRef, useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
-import useScript from "react-script-hook";
-import { Icon, InlineIcon } from "@iconify/react";
-import paperPlane from "@iconify/icons-la/paper-plane";
-import walletSolid from "@iconify/icons-la/wallet-solid";
+import { Icon } from "@iconify/react";
 import streamSolid from "@iconify/icons-la/stream-solid";
 import uploadSolid from "@iconify/icons-la/upload-solid";
 import userIcon from "@iconify/icons-la/user";
 
-import { overmind, useOvermind } from "../stores/Overmind";
+import { useOvermind } from "../stores/Overmind";
 import * as Roll from "../utils/Roll";
+import RollLogin from "../components/RollLogin";
+import BottomSheetModal from "../components/BottomSheetModal";
 
 export default function Layout({ children, url }) {
   const [zoom, setZoom] = useState(1);
   const [_vanta, setVenta] = useState(null);
-  const [state, setState] = useState({ refresh: 0 });
+  const [state] = useState({ refresh: 0 });
   const element = useRef();
 
   // Overmind
@@ -90,6 +88,8 @@ export default function Layout({ children, url }) {
 
   // Previous parent css removed: "grid grid-rows-3" style={{ gridTemplateRows: 'auto 1fr auto' }}
 
+  const { walletConnectModal, redirectTo } = ostate.application;
+
   return (
     <div ref={element} className="w-screen h-screen">
       <Head></Head>
@@ -115,6 +115,12 @@ export default function Layout({ children, url }) {
           </Link>
         </div>
       </footer>
+
+      {walletConnectModal ? (
+        <BottomSheetModal onExit={actions.toggleWalletConnectModal}>
+          <RollLogin redirectTo={redirectTo} />
+        </BottomSheetModal>
+      ) : null}
     </div>
   );
 }

--- a/components/MetaMask.js
+++ b/components/MetaMask.js
@@ -1,41 +1,33 @@
-import React, { useState, useRef, useEffect } from "react";
-import Page from "../components/Page";
-import { Icon, InlineIcon } from "@iconify/react";
-import timesSolid from "@iconify/icons-la/times-solid";
-import Link from "next/link";
-import Lottie from 'react-lottie';
-import animationData from '../src/lotties/browsers';
+import React from "react";
+import Lottie from "react-lottie";
+import animationData from "../src/lotties/browsers";
 
 export default function MetaMask() {
+  const defaultOptions = {
+    loop: true,
+    autoplay: true,
+    animationData: animationData,
+    rendererSettings: {
+      preserveAspectRatio: "xMidYMid slice",
+    },
+  };
 
-    const defaultOptions = {
-        loop: true,
-        autoplay: true,
-        animationData: animationData,
-        rendererSettings: {
-            preserveAspectRatio: "xMidYMid slice"
-        }
-    };
-
-    return (
-        <div className="overflow-hidden">
-            <div className="absolute top-0 right-0">
-                <Link href="post/[slug]">
-                    <Icon icon={timesSolid} className="h-8 w-8 mt-4 mr-4" />
-                </Link>
-            </div>
-            <h1 className="mt-32 tracking-wider text-center font-extrabold text-3xl text-gray-900 text-opacity-100">Authorize Metamask</h1>
-            <p className="mt-4 text-gray-700 text-center tracking-wide text-normal ml-6 mr-6">Use the Metamask popup to allow access</p>
-            <div className="flex flex-col items-center justify-center mt-4">
-                <img src="https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/metamask-fox.svg"
-                    alt="Metamask Logo"
-                    className="h-24 w-24" />
-                <Lottie
-                    options={defaultOptions}
-                    height={200}
-                    width={200}
-                />
-            </div>
-        </div>
-    );
+  return (
+    <div className="overflow-hidden">
+      <h1 className="mt-32 tracking-wider text-center font-extrabold text-3xl text-gray-900 text-opacity-100">
+        Authorize Metamask
+      </h1>
+      <p className="mt-4 text-gray-700 text-center tracking-wide text-normal ml-6 mr-6">
+        Use the Metamask popup to allow access
+      </p>
+      <div className="flex flex-col items-center justify-center mt-4">
+        <img
+          src="https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/metamask-fox.svg"
+          alt="Metamask Logo"
+          className="h-24 w-24"
+        />
+        <Lottie options={defaultOptions} height={200} width={200} />
+      </div>
+    </div>
+  );
 }

--- a/components/Page.js
+++ b/components/Page.js
@@ -13,6 +13,8 @@ import Others from "../pages/upload";
 import WallCard from "./WallCard";
 import Header from "./header";
 
+import { useOvermind } from "../stores/Overmind";
+
 function mf(i) {
   const file = "b";
   return { file, id: Math.random() };
@@ -28,6 +30,8 @@ function Page() {
   const [sampleData, setSampleData] = useState([]);
   const [videos, setVideos] = useState([]);
 
+  const { state: ostate, actions } = useOvermind();
+
   useEffect(() => {
     try {
       getVideos(setVideos);
@@ -36,6 +40,9 @@ function Page() {
       console.log(e);
     }
   }, []);
+  useEffect(() => {
+    if (ostate.user.balances.length === 0) actions.refreshUser();
+  }, [ostate.user.balances, ostate.user]);
 
   // Logic could be recycled for different bottom drawer solution.
 

--- a/components/RollLogin.js
+++ b/components/RollLogin.js
@@ -2,7 +2,8 @@ import React from "react";
 import * as Roll from "../utils/Roll";
 import Link from "next/link";
 
-export default function RollLogin() {
+export default function RollLogin({ redirectTo }) {
+  if (!redirectTo) redirectTo = window.location.href;
   return (
     <div className="container p-6">
       <div className="h-56 w-56 mx-auto mb-16">
@@ -13,7 +14,7 @@ export default function RollLogin() {
       </p>
       <div className="mx-auto mt-12">
         <a
-          href={Roll.loginUrl(window.location.href)}
+          href={Roll.loginUrl(redirectTo)}
           className="flex justify-center w-full p-3 text-center rounded-lg mt-4 bg-blue-500 text-white"
         >
           Open Your Roll Wallet

--- a/components/WallCard.js
+++ b/components/WallCard.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import Link from "next/link";
+import { useRouter } from "next/router";
 import { Icon } from "@iconify/react";
 import playSolid from "@iconify/icons-la/play-solid";
 import lockSolid from "@iconify/icons-la/lock-solid";
@@ -7,9 +7,12 @@ import ellipsisVSolid from "@iconify/icons-la/ellipsis-v-solid";
 import ProfileHeader from "./profileHeader";
 
 import * as UserData from "../utils/UserData";
+import { useOvermind } from "../stores/Overmind";
 
 export default function WallCard({ gif, file }) {
   const [videoMetadata, setVideoMetadata] = useState({});
+  const router = useRouter();
+  const { state: ostate, actions } = useOvermind();
 
   useEffect(() => {
     async function run() {
@@ -22,38 +25,45 @@ export default function WallCard({ gif, file }) {
 
   if (!videoMetadata) return null;
 
+  function onClick() {
+    if (ostate.user.isAuthenticated) {
+      router.push("/post/[slug]", "/post/" + file.id);
+      return;
+    }
+    actions.toggleWalletConnectModal(window.location.href + "post/" + file.id);
+  }
+
   return (
     <div className="container h-screen flex items-center justify-center snap-center always-stop px-6">
-      <Link href="/post/[slug]" as={"/post/" + file?.id}>
-        <div
-          className="relative rounded-md shadow-lg h-48 w-full justify-center cursor-pointer overflow-hidden"
-          style={{
-            backgroundImage: `url(${gif})`,
-            backgroundSize: "cover",
-            backgroundPosition: "50%",
-            height: "75%",
-          }}
-        >
-          <div className="flex absolute top-0 right-0 left-0 p-6">
-            <ProfileHeader />
-            <Icon
-              icon={ellipsisVSolid}
-              color="white"
-              className="top-0 right-0 h-8 w-8"
-            />
-          </div>
-          <div className="absolute bottom-0 left-0 right-0 p-6">
-            <Icon className="w-10 h-10" icon={lockSolid} color="white" />
-            <div className="break-words font-extrabold text-4xl mb-4 p-2 text-white">
-              {videoMetadata.title || "Loading..."}
-            </div>
-
-            <UnlockButton>
-              Own {videoMetadata.tokens} {videoMetadata.tokenName} to Unlock
-            </UnlockButton>
-          </div>
+      <div
+        onClick={onClick}
+        className="relative rounded-md shadow-lg h-48 w-full justify-center cursor-pointer overflow-hidden"
+        style={{
+          backgroundImage: `url(${gif})`,
+          backgroundSize: "cover",
+          backgroundPosition: "50%",
+          height: "75%",
+        }}
+      >
+        <div className="flex absolute top-0 right-0 left-0 p-6">
+          <ProfileHeader />
+          <Icon
+            icon={ellipsisVSolid}
+            color="white"
+            className="top-0 right-0 h-8 w-8"
+          />
         </div>
-      </Link>
+        <div className="absolute bottom-0 left-0 right-0 p-6">
+          <Icon className="w-10 h-10" icon={lockSolid} color="white" />
+          <div className="break-words font-extrabold text-4xl mb-4 p-2 text-white">
+            {videoMetadata.title || "Loading..."}
+          </div>
+
+          <UnlockButton>
+            Own {videoMetadata.tokens} {videoMetadata.tokenName} to Unlock
+          </UnlockButton>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/header.js
+++ b/components/header.js
@@ -1,37 +1,30 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
+import { Icon } from "@iconify/react";
 import Link from "next/link";
+import IconWalletSolid from "@iconify/icons-la/wallet-solid";
+import { useOvermind } from "../stores/Overmind";
 
 export default function Header() {
+  const { state: ostate, actions } = useOvermind();
   return (
-    <div>
-      <nav className="bg-white pt-4 pb-2 justify-left fixed w-full z-10 top-0 rounded-b-lg px-5">
-        <div className="container mx-auto flex flex-wrap items-center">
-          <h3
-            style={{
-              fontStyle: "italic",
-              fontSize: "1.4em",
-              fontWeight: 800,
-              color: "black",
-            }}
-          >
-            🔥 WHAT'S HOT
-          </h3>
-        </div>
-      </nav>
-      {/*
-        <header className="fixed top-0 bg-white w-full h-12">
-            <h3
-                style={{
-                    fontStyle: "italic",
-                    fontSize: "1.4em",
-                    fontWeight: 800,
-                    color: "black",
-                }}
-            >
-                🔥 WHAT'S HOT
-          </h3>
-            </header>*/}
-    </div>
+    <nav className="bg-white pt-4 pb-2 justify-left fixed w-full z-10 top-0 rounded-b-lg px-5">
+      <div className="container mx-auto flex flex-wrap items-center justify-between">
+        <h3
+          style={{
+            fontStyle: "italic",
+            fontSize: "1.4em",
+            fontWeight: 800,
+            color: "black",
+          }}
+        >
+          🔥 WHAT'S HOT
+        </h3>
+        {!ostate.user.isAuthenticated ? (
+          <a onClick={actions.toggleWalletConnectModal}>
+            <Icon icon={IconWalletSolid} className="h-8 w-8" />
+          </a>
+        ) : null}
+      </div>
+    </nav>
   );
 }
-

--- a/pages/post/[slug].js
+++ b/pages/post/[slug].js
@@ -12,6 +12,7 @@ import commentsSolid from "@iconify/icons-la/comments-solid";
 import shareAltSquareSolid from "@iconify/icons-la/share-alt-square-solid";
 import angleRightSolid from "@iconify/icons-la/angle-right-solid";
 import timesCircle from "@iconify/icons-la/times-circle";
+import timesSolid from "@iconify/icons-la/times-solid";
 import storeSolid from "@iconify/icons-la/store-solid";
 import windowClose from "@iconify/icons-la/window-close";
 import baselineShare from "@iconify/icons-ic/baseline-share";
@@ -109,8 +110,8 @@ export default function Slug() {
 
   useEffect(() => {
     if (ostate.user.balances.length === 0) actions.refreshUser();
-  }, [ostate.user.isUnauthenticated, ostate.user.balances, ostate.user]);
-    
+  }, [ostate.user.isAuthenticated, ostate.user.balances, ostate.user]);
+
   let hasEnough = false;
   let balance = 0;
   if (ostate.user.balances.length > 0 && videoObj.tokenName) {
@@ -128,7 +129,7 @@ export default function Slug() {
       );
     }
   }
-  
+
   return (
     <>
       <Head>
@@ -157,11 +158,18 @@ export default function Slug() {
             </div>
           )}
 
-          {ostate.user.isUnauthenticated && state.file && (
-            <RollLogin />
+          {!ostate.user.isAuthenticated && state.file && (
+            <>
+              <div className="absolute top-0 right-0 mt-4 mr-4">
+                <Link href="/">
+                  <Icon icon={timesSolid} className="h-8 w-8 text-gray-700" />
+                </Link>
+              </div>
+              <RollLogin />
+            </>
           )}
 
-          {!ostate.user.isUnauthenticated && state.file && hasEnough && (
+          {ostate.user.isAuthenticated && state.file && hasEnough && (
             <div onClick={unlock}>
               <div className="bg-black bg-opacity-100">
                 <img
@@ -221,7 +229,7 @@ export default function Slug() {
             </div>
           )}
 
-          {!ostate.user.isUnauthenticated && state.file && !hasEnough && (
+          {ostate.user.isAuthenticated && state.file && !hasEnough && (
             <div>
               <a href="https://exchange.tryroll.com/#/swap" target="_blank">
                 <div className="bg-black bg-opacity-100">
@@ -310,4 +318,3 @@ export default function Slug() {
     </>
   );
 }
-

--- a/stores/Overmind.js
+++ b/stores/Overmind.js
@@ -4,65 +4,73 @@ import * as Roll from "../utils/Roll";
 
 export const useOvermind = createHook();
 
-export const overmind = createOvermind({
-  state: {
-    currentStep: 1,
-    username: "",
-    roll: {
-      apiToken: null,
-      apiRefreshToken: null,
-      hasAccess: false,
+export const overmind = createOvermind(
+  {
+    state: {
+      application: {
+        walletConnectModal: false,
+        redirectTo: null,
+      },
+      currentStep: 1,
+      username: "",
+      roll: {
+        apiToken: null,
+        apiRefreshToken: null,
+        hasAccess: false,
+      },
+      user: {
+        isAuthenticated: false,
+        // name: null,
+        // username: null,
+        // email: null,
+        // userTestID: null,
+        wallets: [],
+        balances: [],
+        // refresh: 0,
+      },
     },
-    user: {
-      isUnauthenticated: false,
-      isAuthenticated: false,
-      // name: null,
-      // username: null,
-      // email: null,
-      // userTestID: null,
-      wallets: [],
-      balances: [],
-      // refresh: 0,
-    },
-  },
-  actions: {
-    async refreshUser({ state, actions }) {
-      const user = await Roll.getUserData();
+    actions: {
+      async refreshUser({ state, actions }) {
+        const user = await Roll.getUserData();
 
-      if (!user) {
-        state.user.isUnauthenticated = true;
-        return;
-      }
-      state.user.isUnauthenticated = false;
-      actions.updateUser(user);
-    },
-    updateUser({ state }, user) {
-      if (!user) return;
-      state.user = user;
-
-      // if (user.balances.length > 0) state.user.refresh++;
-    },
-    updateTokens({ state }, params) {
-      const { token, refreshToken, hasAccess } = params;
-
-      // console.log("apiRefreshToken", token, refreshToken, params);
-      state.roll.apiToken = token;
-      state.roll.apiRefreshToken = refreshToken;
-      state.roll.hasAccess = hasAccess;
-
-      if (state.roll.apiToken) {
-        state.user.isUnauthenticated = false;
+        if (!user) {
+          return;
+        }
         state.user.isAuthenticated = true;
-      }
-    },
-    updateStep({ state }, step) {
-      state.currentStep = step;
-    },
-    updateUsername({ state }, username) {
-      state.username = username;
+        actions.updateUser(user);
+      },
+      updateUser({ state }, user) {
+        if (!user) return;
+        state.user = { ...state.user, ...user };
+
+        // if (user.balances.length > 0) state.user.refresh++;
+      },
+      updateTokens({ state }, params) {
+        const { token, refreshToken, hasAccess } = params;
+
+        // console.log("apiRefreshToken", token, refreshToken, params);
+        state.roll.apiToken = token;
+        state.roll.apiRefreshToken = refreshToken;
+        state.roll.hasAccess = hasAccess;
+
+        if (state.roll.apiToken) {
+          state.user.isAuthenticated = true;
+        }
+      },
+      updateStep({ state }, step) {
+        state.currentStep = step;
+      },
+      updateUsername({ state }, username) {
+        state.username = username;
+      },
+      toggleWalletConnectModal({ state }, url) {
+        state.application.walletConnectModal = !state.application
+          .walletConnectModal;
+        state.application.redirectTo = url;
+      },
     },
   },
-},
-{
-  devtools: false,
-});
+  {
+    devtools: false,
+  }
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,17 +10,20 @@ module.exports = {
     ],
   },
   theme: {
+    borderRadius: {
+      xl: "2rem",
+    },
     extend: {
       animation: {
-        'pulse': 'pulse 4s infinite',
+        pulse: "pulse 4s infinite",
       },
       fontFamily: {
-        header: ['Recursive']
-      }
+        header: ["Recursive"],
+      },
     },
   },
   variants: {
-    scrollSnapType: ['responsive'],
+    scrollSnapType: ["responsive"],
   },
-  plugins: [require('tailwindcss-scroll-snap')],
+  plugins: [require("tailwindcss-scroll-snap")],
 };


### PR DESCRIPTION
Rather than displaying RollLogin when the user navigates to a post, we
now preemptively display the RollLogin component in a BottomSheetModal
before the user is routed by checking their isAuthenticated state.

- Add wallet icon to Feed page nav when the user hasn't authenticated
  with Roll. We will probably need to make this persistent as this is
  what the designs call for.
- Create BottomSheetModal. This still needs work to support gestures but
  the user can still tap out of the modal.
- Ensure user is redirected to the post they clicked on after roll auth

![Screen Recording 2020-08-23 at 11 35 PM](https://user-images.githubusercontent.com/1606774/90990409-dab8cf80-e5a9-11ea-9449-a61599903071.gif)
